### PR TITLE
generate explicit value conversion.

### DIFF
--- a/Capsaicin.UnitTesting.Generators.Tests/TestDataSourceGeneratorTest.cs
+++ b/Capsaicin.UnitTesting.Generators.Tests/TestDataSourceGeneratorTest.cs
@@ -43,5 +43,22 @@ namespace Capsaicin.UnitTesting.Generators
             var actual = testObject.ToString(format, formatProvider);
             Assert.AreEqual(expected, actual);
         }
+
+        /// <summary>
+        /// Implicitly tests TestDataSourceGenerator and verifies object values are correctly evaluated
+        /// </summary>
+        /// <param name="notFromExpression"></param>
+        /// <param name="fromExpression"></param>
+        [TestMethod]
+        [ExpressionDataRow(1.23d, "1.23d", typeof(double))]
+        [ExpressionDataRow(0d, "0d", typeof(double))]
+        [ExpressionDataRow(-6d, "-6d", typeof(double))]
+        [ExpressionDataRow(0, "0", typeof(int))]
+        public partial void Generate_ObjectValues_Test(object notFromExpression, [FromCSharpExpression] object fromExpression, Type expectedType)
+        {
+            Assert.IsInstanceOfType(fromExpression, expectedType);
+            Assert.IsInstanceOfType(notFromExpression, expectedType);
+            Assert.AreEqual(notFromExpression, fromExpression);
+        }
     }
 }

--- a/Capsaicin.UnitTesting.Generators/UnitTesting.Generators/TestDataSourceGenerator.ExecuteContext.cs
+++ b/Capsaicin.UnitTesting.Generators/UnitTesting.Generators/TestDataSourceGenerator.ExecuteContext.cs
@@ -167,13 +167,14 @@ namespace {methodSymbol.ContainingNamespace.ToDisplayString()}
                     new object?[]
                     {{");
 
-                    for (int i = 0; i < parametersData.Length; i++)
-                    {
-                        var valueExpression = GetValueExpression(i);
-                        stringBuilder.Append($@"
+                for (int i = 0; i < parametersData.Length; i++)
+                {
+                    //stringBuilder.AppendLine($"// type: {parametersData[i].Type?.Name ?? "<unkown>"}; ToString={parametersData[i].ToString()}");
+                    var valueExpression = GetValueExpression(i);
+                    stringBuilder.Append($@"
                         {valueExpression},");
-                    }
-                    stringBuilder.AppendLine($@"
+                }
+                stringBuilder.AppendLine($@"
                     }}
                 }};
             }}
@@ -204,10 +205,18 @@ namespace {methodSymbol.ContainingNamespace.ToDisplayString()}
                         }
                         else
                         {
-                            return parameterData.Value?.ToString() ?? "null";
+                            return (parameterData.Value?.ToString() ?? "null");
                         }
                     }
-                    return parameterData.ToCSharpString();
+
+                    var value = parameterData.ToCSharpString();
+                    if (parameterData.Type is not null)
+                    {
+                        // explicit conversion required because some constants may not express the correctly typed value (e.g. 0 is integer but a double may be the correct type: (double)0)
+                        // TODO: can we optimize this so that unnecessary conversion is not generated?
+                        value = $"({parameterData.Type.ToDisplayString()}){value}";
+                    }
+                    return value;
                 }
             }
 


### PR DESCRIPTION
Without conversion the runtime value might have wrong type.